### PR TITLE
docs: add upgrade instruction

### DIFF
--- a/mainnet/crescent-1/upgrades/v1.1.0.md
+++ b/mainnet/crescent-1/upgrades/v1.1.0.md
@@ -1,0 +1,20 @@
+# Upgrade Instruction
+
+This document describes the steps for Crescent validators and full node operators to upgrade their nodes.
+
+## Information
+
+This upgrade contains a subtle state-machine breaking change that has been discovered by the Crescent team after closely monitoring transactions. It is about gas consumption issue. Some airdrop recipients encountered "out of gas in location" issue when they claim their claimable amount for governance vote mission. Gas consumption is expected to increase as a number of votes increase. The core team has investigated the root cause and fixed the issue in this [PR #23](https://github.com/crescent-network/crescent/pull/23). After having an intense discussion internally, it is decided to go for this upgrade mechanism rather than going through on-chain governance upgrade proposal `UpgradeProposal` since it is security hot fix that is better to be fixed as soon as it can and also it is directly related to governance proposal. Having another governance proposal and increasing number of votes will make the issue worse at this point.
+
+## Instruction
+
+Upgrade must be proceeded before the block height `48000`, which is 48 hours ahead from the time of writing. The estimated target date is around `Sat Apr 16 2022 09:00:00 UTC`. The upgrade core version is [v1.1.0](https://github.com/crescent-network/crescent/releases/tag/v1.1.0).
+
+```bash
+git clone -b v1.1.0 https://github.com/crescent-network/crescent.git
+cd crescent && make install
+```
+
+## Communications
+
+Operators are encouraged to join the `#validators-general` channel of the Crescent Network Community Discord. This channel is the primary communication tool for operators to ask questions, report upgrade status, report technical issues, and to build social consensus should the need arise.


### PR DESCRIPTION
This PR adds upgrade instruction for [v1.1.0](https://github.com/crescent-network/crescent/releases/tag/v1.1.0) core version.