### PR TITLE
docs: add document for v3 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,36 @@ A repository for coordinating with Crescent genesis validators and documenting i
 
 ## Mainnet Status
 
-### April 13th, 2022 00:00:00 UTC
+### 2022-12-14 06:00:00 UTC
 
 - Chain ID: crescent-1
-- Genesis Time: `2022-04-13T00:00:00Z`
-- Core Version: [v1.1.0](https://github.com/crescent-network/crescent/releases/tag/v1.1.0)
+- Upgrade Height: 3932000
+- Core Version: [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0)
 
-### July 18th, 2022 12:30:00 UTC
+### 2022-07-18 12:30:00 UTC
 
 - Chain ID: crescent-1
 - Upgrade Height: 1384100
 - Core Version: [v2.1.1](https://github.com/crescent-network/crescent/releases/tag/v2.1.1)
 
+### 2022-04-13 00:00:00 UTC
+
+- Chain ID: crescent-1
+- Genesis Time: `2022-04-13T00:00:00Z`
+- Core Version: [v1.1.0](https://github.com/crescent-network/crescent/releases/tag/v1.1.0)
+
 
 ## Testnet Status
 
-### March 18th, 2022 14:00:00 UTC 
 
-- Chain ID: mooncat-1-1
-- Genesis Time: `2022-03-18T14:00:00Z`
-- Core Version: [v1.0.0-rc2](https://github.com/crescent-network/crescent/releases/tag/v1.0.0-rc2)
-
-### 2022 10-07 04:09:46 UTC 
+### 2022-10-07 04:09:46 UTC 
 
 - Chain ID: mooncat-2
 - Genesis Time: `2022-10-07T04:09:46.065014743Z`
 - Core Version: [v2.1.1](https://github.com/crescent-network/crescent/releases/tag/v2.1.1)
+
+### 2022-03-18 14:00:00 UTC 
+
+- Chain ID: mooncat-1-1
+- Genesis Time: `2022-03-18T14:00:00Z`
+- Core Version: [v1.0.0-rc2](https://github.com/crescent-network/crescent/releases/tag/v1.0.0-rc2)

--- a/mainnet/crescent-1/upgrades/v3.0.0.md
+++ b/mainnet/crescent-1/upgrades/v3.0.0.md
@@ -1,0 +1,171 @@
+# Upgrade Instruction for v3.0.0
+
+This document describes the steps for all Crescent validators and full node operators to upgrade their nodes with [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0). Reference [CHANGELOG.md](https://github.com/crescent-network/crescent/blob/v3.0.0/CHANGELOG.md) for the changes.
+
+## Information
+
+- Proposal #: **29**
+- Chain ID: **crescent-1**
+- Upgrade Name: **v3.0.0**
+- Upgrade Height: **TBD**
+- Estimated Upgrade Date and Time: **TBD**
+- Binary: [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) to [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0)
+
+
+## Chain ID
+
+The chain-id of the network will **NOT BE CHANGED**. It will remain the same as `crescent-1`. This is because an in-place migration of state will take place, which means that this upgrade does not require to export any state.
+
+## Block Height and Time
+
+The upgrade will take place at a block height `TBD`. At the time of writing, an estimated upgrade time is `TBD` at current block time (around 6s/block). This date/time is approximate as blocks are not generated at a constant interval, so we encourage all validators and node operators to expect this and standby around the time. 
+
+## Preparation
+
+### **Backup**
+
+Prior to the upgrade, it is **IMPORTANT** that validators are prepared to have either a full data snapshot or use third-party trusted data source. Snapshotting depends heavily on infrastructure, but generally this can be done by backing up the data directory, which resides in `$HOME/.crescent`. If you use `Cosmovisor` to upgrade, `Cosmovisor` will backup your data upon upgrade by default.
+
+Once again, it is critically important for validator operators to back-up the `.crescent/data/priv_validator_state.json` file after stopping the crescentd process. This file is updated every block as your validator participates in consensus rounds. It is a critical file needed to prevent double-signing, in case the upgrade fails and the previous chain needs to be restarted.
+
+### Current Version
+
+Current Mainnet is running with [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) with the chain id `crescent-1`.
+
+### Target Version
+
+All Crescent validators and node operators **MUST** use [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0) to upgrade their nodes to remain connected to the network.
+
+### (Important) Update `config.toml`
+
+In this upgrade, we introduce Crescent's newly implemented orderbook functionality. In order to run it smoothly, the block time is suggested to be shortened to improve user experience. We kindly ask you to update `timeout_commit` value to `4s` in the `config.toml` file, which is located in `$HOME/.crescent/config/` directory.
+
+## Upgrade Steps
+
+The following ways are the 2 major ways to upgrade a node:
+
+- Manual Upgrade
+- Upgrade using [Cosmovisor](https://github.com/cosmos/cosmos-sdk/tree/master/cosmovisor)
+
+If you prefer to use `Cosmovisor` to upgrade, some preparation work is needed before upgrade, such as new binary must be prepared manually.
+
+### Method I: Manual Upgrade (Recommended)
+
+You are running `crescentd` with [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) until the upgrade height and the node will panic with the following logs:
+
+```
+ERR UPGRADE "v3.0.0" NEEDED at height: TBD
+ERR CONSENSUS FAILURE!!! err="UPGRADE "v3.0.0" NEEDED at height: TBD
+...
+.....
+.......
+```
+
+Now, stop the node and install new binary with [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0) and restart node with the following command `crescentd start`.
+
+This may take from 20 minutes to a few hours depending on validators participation. A total sum voting power > 2/3 is required to start chain to produce next blocks.
+
+### Method II: Upgrade using `Cosmovisor` 
+
+### Preparation
+
+Install the latest version of `Cosmovisor`:
+
+```bash
+# The latest version may be different, so make sure you check the version
+go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+```
+
+Create a `cosmovisor` folder inside `$CRESCENT_HOME` and move `crescentd (v3.0.0)` into `$CRESCENT_HOME/cosmovisor/genesis/bin` directory.
+
+```bash
+export CRESCENT_HOME={SET_YOUR_CRESCENT_HOME}
+$(which crescentd) version # v3.0.0
+
+mkdir -p $CRESCENT_HOME/cosmovisor/genesis/bin
+cp $(which crescentd) $CRESCENT_HOME/cosmovisor/genesis/bin
+```
+
+Build Crescent `v3.0.0` and move `crescentd` to `$CRESCENT_HOME/cosmovisor/upgrades/v3.0.0/bin` directory.
+
+```bash
+export CRESCENT_UPGRADE_PATH={SET_YOUR_PATH}
+$CRESCENT_UPGRADE_PATH version # v3.0.0
+
+mkdir -p  $CRESCENT_HOME/cosmovisor/upgrades/v3.0.0/bin
+cp $CRESCENT_UPGRADE_PATH $CRESCENT_HOME/cosmovisor/upgrades/v3.0.0/bin
+```
+
+Then you should get the following structure:
+
+```
+.
+├── current -> genesis or upgrades/<name>
+├── genesis
+│   └── bin
+│       └── crescentd  #v2.3.0
+└── upgrades
+└── v3.0.0
+└── bin
+    └── crescentd  #v3.0.0
+```
+
+Export the environmental variables:
+
+```bash
+export DAEMON_NAME=crescentd
+export DAEMON_HOME=$CRESCENT_HOME # USE YOUR OWN HOME DIRECTORY
+export DAEMON_RESTART_AFTER_UPGRADE=true
+```
+
+Start the node:
+
+```bash
+cosmovisor start --x-crisis-skip-assert-invariants
+```
+
+### Expected Upgrade Result
+
+When the upgrade block height is reached, you can find the following information in the log:
+
+```
+ERR UPGRADE "v3.0.0" NEEDED at height: 1384100: upgrade to v3.0.0 and applying upgrade "v3.0.0" at height:1384100.
+```
+
+This may take 20 min to a few hours.
+After this, the chain will continue to produce blocks when validators with a total sum voting power > 2/3 complete their nodes upgrades.
+
+### ~~Method III: upgrade using Cosmovisor by auto-downloading the Crescent ****v2.1.0**** binary~~
+
+This update is not applicable for this method, `binaries` is not set to upgrade-info of upgrade proposal, so please use method 1 and 2.
+
+## Upgrade duration
+
+The upgrade may take several hours to complete because `crescent-1` participants operate globally with differing operating hours and it may take some time for operators to upgrade their binaries and connect to the network.
+
+## Rollback plan
+
+During the network upgrade, core Crescent teams will be keeping an ever vigilant eye and communicating with operators on the status of their upgrades. During this time, the core teams will listen to operator needs to determine if the upgrade is experiencing unintended challenges. In the event of unexpected challenges, the core teams, after conferring with operators and attaining social consensus, may choose to declare that the upgrade will be skipped.
+
+Steps to skip this upgrade proposal are simply to resume the crescent-1 network with the (downgraded) v1.1.0 binary using the following command:
+
+> crescentd start --unsafe-skip-upgrade TBD
+>
+
+Note: There is no particular need to restore a state snapshot prior to the upgrade height, unless specifically directed by core Crescent teams.
+
+Important: A social consensus decision to skip the upgrade will be based solely on technical merits, thereby respecting and maintaining the decentralized governance process of the upgrade proposal's successful YES vote.
+
+## Communications
+
+Operators are encouraged to join the `#validators-general` channel of the Crescent Network Community Discord. This channel is the primary communication tool for operators to ask questions, report upgrade status, report technical issues, and to build social consensus should the need arise. 
+
+## Risks
+
+As a validator performing the upgrade procedure on your consensus nodes carries a heightened risk of double-signing and being slashed. The most important piece of this procedure is verifying your software version and genesis file hash before starting your validator and signing.
+
+The riskiest thing a validator can do is discover that they made a mistake and repeat the upgrade procedure again during the network startup. If you discover a mistake in the process, the best thing to do is wait for the network to start before correcting it.
+
+## Reference
+
+[Cosmos Hub 4, Vega Upgrade, Instructions](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-vega-upgrade.md)

--- a/mainnet/crescent-1/upgrades/v3.0.0.md
+++ b/mainnet/crescent-1/upgrades/v3.0.0.md
@@ -7,8 +7,8 @@ This document describes the steps for all Crescent validators and full node oper
 - Proposal #: **29**
 - Chain ID: **crescent-1**
 - Upgrade Name: **v3.0.0**
-- Upgrade Height: **TBD**
-- Estimated Upgrade Date and Time: **TBD**
+- Upgrade Height: **3932000**
+- Estimated Upgrade Date and Time: **2022-12-14T06:00:00+0000 UTC**
 - Binary: [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) to [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0)
 
 
@@ -18,7 +18,7 @@ The chain-id of the network will **NOT BE CHANGED**. It will remain the same as 
 
 ## Block Height and Time
 
-The upgrade will take place at a block height `TBD`. At the time of writing, an estimated upgrade time is `TBD` at current block time (around 6s/block). This date/time is approximate as blocks are not generated at a constant interval, so we encourage all validators and node operators to expect this and standby around the time. 
+The upgrade will take place at a block height `3932000`. At the time of writing, an estimated upgrade time is `2022-12-14T06:00:00+0000 UTC` at current block time (around 5s/block). This date/time is approximate as blocks are not generated at a constant interval, so we encourage all validators and node operators to expect this and standby around the time. 
 
 ## Preparation
 
@@ -36,10 +36,6 @@ Current Mainnet is running with [v2.3.0](https://github.com/crescent-network/cre
 
 All Crescent validators and node operators **MUST** use [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0) to upgrade their nodes to remain connected to the network.
 
-### (Important) Update `config.toml`
-
-In this upgrade, we introduce Crescent's newly implemented orderbook functionality. In order to run it smoothly, the block time is suggested to be shortened to improve user experience. We kindly ask you to update `timeout_commit` value to `4s` in the `config.toml` file, which is located in `$HOME/.crescent/config/` directory.
-
 ## Upgrade Steps
 
 The following ways are the 2 major ways to upgrade a node:
@@ -54,8 +50,8 @@ If you prefer to use `Cosmovisor` to upgrade, some preparation work is needed be
 You are running `crescentd` with [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) until the upgrade height and the node will panic with the following logs:
 
 ```
-ERR UPGRADE "v3.0.0" NEEDED at height: TBD
-ERR CONSENSUS FAILURE!!! err="UPGRADE "v3.0.0" NEEDED at height: TBD
+ERR UPGRADE "v3" NEEDED at height: 20: v3: Farming V2, LiquidFarming, Market Maker Incentive Core Upgrade
+ERR CONSENSUS FAILURE!!! err="UPGRADE \"v3\" NEEDED at height: 20: v3: Farming V2, LiquidFarming, Market Maker Incentive Core Upgrade"
 ...
 .....
 .......
@@ -72,8 +68,9 @@ This may take from 20 minutes to a few hours depending on validators participati
 Install the latest version of `Cosmovisor`:
 
 ```bash
-# The latest version may be different, so make sure you check the version
-go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+# Reference the below link for Cosmovisor
+# https://docs.cosmos.network/main/tooling/cosmovisor#installation
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 ```
 
 Create a `cosmovisor` folder inside `$CRESCENT_HOME` and move `crescentd (v3.0.0)` into `$CRESCENT_HOME/cosmovisor/genesis/bin` directory.
@@ -129,7 +126,8 @@ cosmovisor start --x-crisis-skip-assert-invariants
 When the upgrade block height is reached, you can find the following information in the log:
 
 ```
-ERR UPGRADE "v3.0.0" NEEDED at height: 1384100: upgrade to v3.0.0 and applying upgrade "v3.0.0" at height:1384100.
+ERR UPGRADE "v3" NEEDED at height: 20: v3: Farming V2, LiquidFarming, Market Maker Incentive Core Upgrade
+ERR CONSENSUS FAILURE!!! err="UPGRADE \"v3\" NEEDED at height: 20: v3: Farming V2, LiquidFarming, Market Maker Incentive Core Upgrade"
 ```
 
 This may take 20 min to a few hours.
@@ -147,9 +145,9 @@ The upgrade may take several hours to complete because `crescent-1` participants
 
 During the network upgrade, core Crescent teams will be keeping an ever vigilant eye and communicating with operators on the status of their upgrades. During this time, the core teams will listen to operator needs to determine if the upgrade is experiencing unintended challenges. In the event of unexpected challenges, the core teams, after conferring with operators and attaining social consensus, may choose to declare that the upgrade will be skipped.
 
-Steps to skip this upgrade proposal are simply to resume the crescent-1 network with the (downgraded) v1.1.0 binary using the following command:
+Steps to skip this upgrade proposal are simply to resume the crescent-1 network with the (downgraded) **v2.3.0** binary using the following command:
 
-> crescentd start --unsafe-skip-upgrade TBD
+> crescentd start --unsafe-skip-upgrade 3932000
 >
 
 Note: There is no particular need to restore a state snapshot prior to the upgrade height, unless specifically directed by core Crescent teams.

--- a/mainnet/crescent-1/upgrades/v3.0.0.md
+++ b/mainnet/crescent-1/upgrades/v3.0.0.md
@@ -6,11 +6,10 @@ This document describes the steps for all Crescent validators and full node oper
 
 - Proposal #: **29**
 - Chain ID: **crescent-1**
-- Upgrade Name: **v3.0.0**
+- Upgrade Name: **v3**
 - Upgrade Height: **3932000**
 - Estimated Upgrade Date and Time: **2022-12-14T06:00:00+0000 UTC**
 - Binary: [v2.3.0](https://github.com/crescent-network/crescent/releases/tag/v2.3.0) to [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0)
-
 
 ## Chain ID
 

--- a/mainnet/crescent-1/upgrades/v3.md
+++ b/mainnet/crescent-1/upgrades/v3.md
@@ -1,4 +1,4 @@
-# Upgrade Instruction for v3.0.0
+# Upgrade Instruction for v3
 
 This document describes the steps for all Crescent validators and full node operators to upgrade their nodes with [v3.0.0](https://github.com/crescent-network/crescent/releases/tag/v3.0.0). Reference [CHANGELOG.md](https://github.com/crescent-network/crescent/blob/v3.0.0/CHANGELOG.md) for the changes.
 


### PR DESCRIPTION
## Description

This PR adds `v3.md` document for upgrade process.

- Upgrade Block Height: 3932000
- Estimated Upgrade Date and Time: 2022-12-14T06:00:00+0000 UTC

## Tasks

- [x] Add `v3.md` document that explains about upgrade process
- [x] Update Mainnet information in `README.md`

## Discussion

- [x] We have to discuss and decide what block height we target for the upcoming upgrade.
- [x] `v3.md` is copied and pasted from `v2.0.0.md` file which contains an instruction about updating `timeout_commit` value in `config.toml` file for full node operators. Can we remove that part?
- [x] Polish instruction